### PR TITLE
CEP M0 — Realtime Event Dashboard POC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: setup dev up down run-pipeline test format
+.PHONY: setup dev up down run-pipeline run-event-dashboard test format
 setup:
 	python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
 dev:
@@ -10,6 +10,8 @@ down:
 	docker compose down
 run-pipeline:
 	source .venv/bin/activate && python -m src.core.pipeline --config configs/example_equity.yaml
+run-event-dashboard:
+	source .venv/bin/activate && uvicorn apps.event_dashboard.server:app --host 127.0.0.1 --port 8010 --reload
 test:
 	source .venv/bin/activate && python -m pytest
 format:

--- a/apps/event_dashboard/public/index.html
+++ b/apps/event_dashboard/public/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Event-Aware Trading Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
+  <style>
+    body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system; background: #0b0e11; color: #e6e6e6; }
+    header { padding: 12px 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid #20252b; }
+    .badge { padding: 2px 8px; border-radius: 999px; background: #1f2937; font-size: 12px; }
+    #chart { height: 560px; }
+    .legend { display:flex; gap:12px; font-size: 12px; padding: 8px 16px; color: #a7b0bd;}
+    .legend span { display:inline-flex; align-items:center; gap:6px;}
+    .dot{width:8px;height:8px;border-radius:999px;display:inline-block}
+    .dot.green{background:#22c55e}.dot.red{background:#ef4444}.dot.blue{background:#60a5fa}.dot.yellow{background:#eab308}
+    .panel { display:flex; gap:16px; padding: 8px 16px; font-size: 12px; color:#a7b0bd; }
+    .panel .kv { background:#0e1318;border:1px solid #20252b;border-radius:10px;padding:6px 10px;}
+  </style>
+</head>
+<body>
+  <header>
+    <strong>SPY — Event Overlay</strong>
+    <span class="badge">lightweight-charts</span>
+    <span class="badge">Live demo</span>
+  </header>
+  <div id="chart"></div>
+  <div class="legend">
+    <span><i class="dot blue"></i> Bar</span>
+    <span><i class="dot green"></i> Breakout / NewsBurst</span>
+    <span><i class="dot yellow"></i> MacroShock</span>
+    <span><i class="dot red"></i> TradeEntryIntent</span>
+  </div>
+  <div class="panel" id="status">
+    <div class="kv">WS: <b id="wsState">connecting…</b></div>
+    <div class="kv">Last event: <b id="lastEvt">—</b></div>
+  </div>
+
+  <script>
+    const container = document.getElementById('chart');
+    const chart = LightweightCharts.createChart(container, {
+      layout: { background: { color: '#0b0e11' }, textColor: '#e6e6e6' },
+      grid: { vertLines: { color: '#1a1f25' }, horzLines: { color: '#1a1f25' } },
+      timeScale: { timeVisible: true, secondsVisible: true, borderColor: '#20252b' },
+      rightPriceScale: { borderColor: '#20252b' },
+      crosshair: { mode: LightweightCharts.CrosshairMode.Normal },
+    });
+    const candleSeries = chart.addCandlestickSeries({
+      upColor: '#22c55e', downColor: '#ef4444', borderDownColor: '#ef4444', borderUpColor: '#22c55e', wickDownColor: '#ef4444', wickUpColor: '#22c55e'
+    });
+
+    const markers = [];
+
+    fetch('/candles').then(r => r.json()).then(rows => {
+      candleSeries.setData(rows.map(k => ({ time: k.time, open: k.open, high: k.high, low: k.low, close: k.close })));
+    });
+
+    function addMarker(time, position, color, shape, text, id) {
+      markers.push({ time, position, color, shape, text, id });
+      candleSeries.setMarkers(markers);
+    }
+
+    const wsState = document.getElementById('wsState');
+    const lastEvt = document.getElementById('lastEvt');
+
+    const ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws');
+    ws.onopen = () => wsState.textContent = 'connected';
+    ws.onclose = () => wsState.textContent = 'disconnected';
+    ws.onerror = () => wsState.textContent = 'error';
+
+    ws.onmessage = (m) => {
+      const evt = JSON.parse(m.data);
+      lastEvt.textContent = `${evt.type} @ ${new Date(evt.ts * 1000).toLocaleTimeString()}`;
+
+      if (evt.type === 'Bar') {
+        const k = evt.data;
+        candleSeries.update({ time: k.time, open: k.open, high: k.high, low: k.low, close: k.close });
+      }
+      if (evt.type === 'Breakout') {
+        addMarker(evt.ts, 'aboveBar', '#22c55e', 'arrowUp', 'Breakout', evt.data?.price);
+      }
+      if (evt.type === 'NewsBurst') {
+        addMarker(evt.ts, 'aboveBar', '#22c55e', 'circle', 'NewsBurst (≥3 pos in 2m)', 'news'+evt.ts);
+      }
+      if (evt.type === 'MacroShock') {
+        addMarker(evt.ts, 'belowBar', '#eab308', 'square', `MacroShock (CPI ${evt.data.surprise.toFixed(2)})`, 'macro'+evt.ts);
+      }
+      if (evt.type === 'TradeEntryIntent') {
+        addMarker(evt.ts, 'belowBar', '#ef4444', 'arrowUp', 'TradeEntryIntent (macro→breakout)', 'entry'+evt.ts);
+      }
+      if (evt.type === 'NewsItem') { console.log('News:', evt.data.headline, 'sent:', evt.data.sentiment); }
+    };
+
+    new ResizeObserver(entries => {
+      if (!entries.length) return;
+      const { width, height } = entries[0].contentRect;
+      chart.applyOptions({ width, height });
+    }).observe(container);
+  </script>
+</body>
+</html>
+

--- a/apps/event_dashboard/server.py
+++ b/apps/event_dashboard/server.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+import asyncio, random, time, uuid
+from dataclasses import dataclass, field, asdict
+from typing import Any, Callable, Deque, Dict, List, Optional
+from collections import defaultdict, deque
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+# ---------- Event model ----------
+@dataclass
+class Event:
+    type: str
+    ts: float = field(default_factory=lambda: time.time())
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    key: Optional[str] = None
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self):
+        return asdict(self)
+
+# Convenience events
+def Bar(symbol: str, o: float, h: float, l: float, c: float, v: float) -> Event:
+    return Event("Bar", key=symbol, data={"open": o, "high": h, "low": l, "close": c, "volume": v})
+
+def NewsItem(symbol: str, sentiment: float, headline: str) -> Event:
+    return Event("NewsItem", key=symbol, data={"sentiment": sentiment, "headline": headline})
+
+def MacroRelease(series: str, actual: float, estimate: float) -> Event:
+    return Event("MacroRelease", key=series, data={"series": series, "actual": actual, "estimate": estimate, "surprise": actual - estimate})
+
+# ---------- Simple CEP core ----------
+class EventSink:
+    def __init__(self):
+        self._subs: List[Callable[[Event], Any]] = []
+    def subscribe(self, fn: Callable[[Event], Any]):
+        self._subs.append(fn)
+    def emit(self, evt: Event):
+        for fn in list(self._subs):
+            fn(evt)
+
+class CEP:
+    def __init__(self):
+        self.sink = EventSink()
+        self._rules: List[Callable[[Event], None]] = []
+
+    def ingest(self, evt: Event):
+        for r in self._rules:
+            r(evt)
+
+    # A then B within T (per key)
+    def on_sequence(self, *, name: str, first_type: str, then_type: str, within_sec: float,
+                    where_first=None, where_then=None, emit_type="SequenceMatched"):
+        states: Dict[str, Deque[Event]] = defaultdict(deque)
+        def rule(evt: Event):
+            k, now = evt.key or "", evt.ts
+            q = states[k]
+            while q and (now - q[0].ts) > within_sec:
+                q.popleft()
+            if evt.type == first_type:
+                if not where_first or where_first(evt):
+                    q.append(evt)
+            elif evt.type == then_type:
+                for a in reversed(q):
+                    if (not where_first or where_first(a)) and (not where_then or where_then(a, evt)):
+                        self.sink.emit(Event(emit_type, key=k, ts=evt.ts, data={"rule": name, "first": a.to_dict(), "then": evt.to_dict()}))
+                        try:
+                            q.remove(a)
+                        except ValueError:
+                            pass
+                        break
+        self._rules.append(rule)
+
+    # Sliding count >= threshold (per key)
+    def on_sliding_count(self, *, name: str, event_type: str, within_sec: float, threshold: int,
+                         where=None, emit_type="ThresholdHit"):
+        buckets: Dict[str, Deque[Event]] = defaultdict(deque)
+        def rule(evt: Event):
+            if evt.type != event_type:
+                return
+            if where and not where(evt):
+                return
+            k, now = evt.key or "", evt.ts
+            q = buckets[k]; q.append(evt)
+            while q and (now - q[0].ts) > within_sec:
+                q.popleft()
+            if len(q) >= threshold:
+                self.sink.emit(Event(emit_type, key=k, ts=evt.ts, data={"rule": name, "count": len(q), "last": evt.to_dict()}))
+        self._rules.append(rule)
+
+    # Macro shock detector (simple example)
+    def on_macro_shock(self, *, series: str, surprise_abs_ge: float, emit_type="MacroShock"):
+        def rule(evt: Event):
+            if evt.type == "MacroRelease" and evt.data.get("series") == series:
+                surprise = abs(evt.data.get("surprise", 0.0))
+                if surprise >= surprise_abs_ge:
+                    self.sink.emit(Event(emit_type, key=series, ts=evt.ts, data={"series": series, "surprise": evt.data["surprise"]}))
+        self._rules.append(rule)
+
+# ---------- FastAPI app & live push ----------
+app = FastAPI(title="Event Dashboard")
+# Serve static assets under /static and index at /
+app.mount("/static", StaticFiles(directory="apps/event_dashboard/public"), name="static")
+
+@app.get("/")
+async def index():
+    # Serve the SPA index
+    return StaticFiles(directory="apps/event_dashboard/public").lookup_path("index.html")[0]
+
+
+SYMBOL = "SPY"
+candles: List[Dict[str, Any]] = []
+clients: List[WebSocket] = []
+clients_lock = asyncio.Lock()
+
+cep = CEP()
+
+async def broadcast(evt: Event):
+    msg = {"type": evt.type, "key": evt.key, "ts": int(evt.ts), "data": evt.data}
+    async with clients_lock:
+        dead: List[WebSocket] = []
+        for ws in clients:
+            try:
+                await ws.send_json(msg)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            try:
+                clients.remove(ws)
+            except ValueError:
+                pass
+
+# Connect CEP → frontend
+cep.sink.subscribe(lambda e: asyncio.create_task(broadcast(e)))
+
+@app.get("/candles")
+async def get_candles(symbol: str = SYMBOL):
+    return JSONResponse(candles[-2000:])
+
+@app.websocket("/ws")
+async def ws(ws: WebSocket):
+    await ws.accept()
+    async with clients_lock:
+        clients.append(ws)
+    try:
+        while True:
+            await ws.receive_text()  # keep alive; ignore content
+    except WebSocketDisconnect:
+        async with clients_lock:
+            try:
+                clients.remove(ws)
+            except ValueError:
+                pass
+
+# ---------- Demo price feed & CEP rules ----------
+
+def next_candle(prev_close: float) -> Dict[str, Any]:
+    t = int(time.time())
+    drift = random.uniform(-0.2, 0.2)
+    o = prev_close
+    c = max(1.0, o + drift + random.uniform(-0.4, 0.4))
+    h = max(o, c) + random.uniform(0.0, 0.3)
+    l = min(o, c) - random.uniform(0.0, 0.3)
+    v = random.randint(1000, 5000)
+    return {"time": t, "open": round(o,2), "high": round(h,2), "low": round(l,2), "close": round(c,2), "volume": v}
+
+async def price_loop():
+    # seed
+    base = 450.0
+    last = base
+    for _ in range(200):
+        k = next_candle(last); last = k["close"]; candles.append(k)
+    while True:
+        await asyncio.sleep(1.0)
+        k = next_candle(candles[-1]["close"])
+        candles.append(k)
+        await broadcast(Event("Bar", key=SYMBOL, ts=k["time"], data=k))
+        cep.ingest(Bar(SYMBOL, k["open"], k["high"], k["low"], k["close"], k["volume"]))
+        if len(candles) >= 21:
+            hh20 = max(c["high"] for c in candles[-20:])
+            if k["close"] > hh20:
+                cep.sink.emit(Event("Breakout", key=SYMBOL, ts=k["time"], data={"price": k["close"], "lookback": 20}))
+
+async def news_loop():
+    headlines_pos = ["Analyst upgrade", "Buyback announced", "Strong sector flows"]
+    headlines_neg = ["Regulatory probe", "Guidance cut", "Industry strike risk"]
+    while True:
+        await asyncio.sleep(random.uniform(7, 12))
+        sent = random.choice([+0.7, +0.8, -0.7, -0.8])
+        hl = random.choice(headlines_pos if sent > 0 else headlines_neg)
+        evt = NewsItem(SYMBOL, sentiment=sent, headline=hl)
+        cep.ingest(evt)
+        await broadcast(evt)
+
+async def macro_loop():
+    while True:
+        await asyncio.sleep(random.uniform(45, 75))
+        est = random.uniform(0.0, 0.4)
+        act = est + random.choice([-0.5, -0.3, +0.3, +0.5])
+        evt = MacroRelease("US:CPI", actual=act, estimate=est)
+        cep.ingest(evt)
+        await broadcast(evt)
+
+# CEP rules
+
+def install_rules():
+    cep.on_sliding_count(
+        name="news_burst_pos",
+        event_type="NewsItem",
+        within_sec=120,
+        threshold=3,
+        where=lambda n: n.data.get("sentiment", 0) >= 0.6 and n.key == SYMBOL,
+        emit_type="NewsBurst",
+    )
+    cep.on_macro_shock(series="US:CPI", surprise_abs_ge=0.3, emit_type="MacroShock")
+    cep.on_sequence(
+        name="macro_then_breakout",
+        first_type="MacroShock", then_type="Breakout",
+        within_sec=15*60,
+        where_then=lambda m,b: True,
+        emit_type="TradeEntryIntent",
+    )
+
+@app.on_event("startup")
+async def on_startup():
+    install_rules()
+    asyncio.create_task(price_loop())
+    asyncio.create_task(news_loop())
+    asyncio.create_task(macro_loop())
+
+

--- a/docs/tasks/cep_m0_plan.md
+++ b/docs/tasks/cep_m0_plan.md
@@ -1,0 +1,38 @@
+# CEP Milestone M0 — Realtime POC
+
+Scope
+- FastAPI app with /candles seed and /ws push
+- Minimal CEP: sliding count (NewsBurst), macro shock (MacroShock), sequence (MacroShock→Breakout)
+- Simulated feeds (bars, news, macro); hooks for live adapters
+- Frontend: lightweight-charts, markers, event tracks (macro/news/signals), drawer stub
+- Tests: /candles returns seed; WS handshake; CEP emits on synthetic triggers
+
+Tasks
+1) App scaffold [backend]
+   - Create apps/event_dashboard/server.py (FastAPI, StaticFiles public/, WS, /candles)
+   - In-memory state: candles[], clients[], CEP core
+   - Broadcast loop and CEP sink subscription
+2) Frontend scaffold [frontend]
+   - public/index.html with chart, markers, event tracks, WS client
+   - Fetch /candles for initial seed; render markers on events
+3) CEP rules [backend]
+   - on_sliding_count for NewsBurst (≥3 pos in 2m)
+   - on_macro_shock for CPI surprise ≥0.3
+   - on_sequence MacroShock then Breakout within 15m
+4) Simulated feeds [backend]
+   - price_loop: 1s candles; breakout detect against hh20
+   - news_loop: random positive/negative every 7–12s
+   - macro_loop: surprise every 45–75s
+5) Tests [tests]
+   - test_candles_seed: GET /candles returns list of dicts with OHLC
+   - test_ws_handshake: connect /ws and receive Bar within timeout
+   - test_cep_emit: drive rule with synthetic events and expect emit
+6) Dev tooling [repo]
+   - Makefile target run-event-dashboard
+   - README snippet under apps/event_dashboard/README.md
+
+Exit criteria
+- App runs: `uvicorn apps.event_dashboard.server:app` and shows live markers
+- All tests pass
+- No external keys required
+

--- a/tests/test_event_dashboard.py
+++ b/tests/test_event_dashboard.py
@@ -1,0 +1,59 @@
+import time
+from fastapi.testclient import TestClient
+
+# Import the server app and CEP utilities
+from apps.event_dashboard import server as srv
+
+
+def test_candles_seed_nonempty():
+    # Use lifespan context so startup tasks run
+    with TestClient(srv.app) as client:
+        data = []
+        # Poll up to ~3s for seed to appear
+        for _ in range(60):
+            r = client.get("/candles")
+            assert r.status_code == 200
+            data = r.json()
+            if data:
+                break
+            time.sleep(0.05)
+        assert isinstance(data, list) and len(data) > 0
+        k = data[-1]
+        for f in ["time", "open", "high", "low", "close"]:
+            assert f in k
+
+
+def test_ws_receives_bar():
+    with TestClient(srv.app) as client:
+        with client.websocket_connect("/ws") as ws:
+            # Expect a Bar or any event within a short timeout
+            msg = ws.receive_json()
+            assert isinstance(msg, dict)
+            assert msg.get("type") in {"Bar", "Breakout", "NewsBurst", "MacroShock", "TradeEntryIntent"}
+
+
+def test_cep_emit_news_burst():
+    cep = srv.CEP()
+    emitted = []
+    cep.sink.subscribe(lambda e: emitted.append(e))
+
+    # Register sliding count rule to emit NewsBurst
+    cep.on_sliding_count(
+        name="test_news_burst",
+        event_type="NewsItem",
+        within_sec=120,
+        threshold=3,
+        where=lambda n: n.data.get("sentiment", 0) >= 0.6,
+        emit_type="NewsBurst",
+    )
+
+    t0 = time.time()
+    e1 = srv.Event("NewsItem", ts=t0, key="SPY", data={"sentiment": 0.7, "headline": "A"})
+    e2 = srv.Event("NewsItem", ts=t0 + 1, key="SPY", data={"sentiment": 0.8, "headline": "B"})
+    e3 = srv.Event("NewsItem", ts=t0 + 2, key="SPY", data={"sentiment": 0.9, "headline": "C"})
+
+    for e in [e1, e2, e3]:
+        cep.ingest(e)
+
+    assert any(e.type == "NewsBurst" for e in emitted)
+


### PR DESCRIPTION
This PR adds a minimal realtime event-aware dashboard per CEP.md (Milestone M0).

Backend
- FastAPI app apps/event_dashboard/server.py
  - GET /candles seed, WebSocket /ws push
  - CEP core: sliding count (NewsBurst), macro shock (MacroShock), sequence (MacroShock→Breakout)
  - Simulated feeds: 1s bars with Breakout detection, news bursts, macro surprises

Frontend
- apps/event_dashboard/public/index.html
  - TradingView lightweight-charts candlestick
  - Markers for Breakout, NewsBurst, MacroShock, TradeEntryIntent
  - Fetches /candles for seed, live updates via WS

Tooling & Tests
- Makefile run-event-dashboard target
- tests/test_event_dashboard.py: candles seed, WS handshake, CEP emit unit test
- docs/tasks/cep_m0_plan.md: scope/tasks/exit criteria

Notes
- No external API keys required; fully simulated
- Deprecation: uses on_event startup; can migrate to lifespan in a follow-up

All tests pass locally (`pytest -q`).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author